### PR TITLE
feat(tv-modal): add Finviz-style fundamentals beside TradingView chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,22 @@ Each table is a **FinViz Elite screener/export** (see `FINVIZ_SCREENER_URLS` / `
 
 ---
 
-## Ticker clicks
+## Ticker clicks (chart + fundamentals)
 
-Clicking a symbol opens a **TradingView** chart modal (client-side).
+Clicking any **`.tv-ticker`** symbol (tables, grids, watchlist, etc.) opens a modal with:
+
+1. **TradingView** embedded chart (same behavior as before; client-side iframe URL).
+2. **Fundamentals panel** to the right (desktop) or below (narrow widths): a dense, Finviz-style grid of **all columns** from the cached FinViz Elite **USA full export** (v=152) for that symbol when it appears in `usa_full_v152`. If the symbol is not in that export, the app falls back to **`quote.ashx`** (single-ticker snapshot) when Elite is configured.
+
+**Implementation notes:**
+
+| Piece | Role |
+|-------|------|
+| `GET /api/ticker-metrics/<symbol>` | Flask route on `app.server`; returns JSON `{ ok, symbol, source, pairs }`. `source` is `usa_v152`, `quote`, or unavailable. |
+| `src/ticker_metrics.py` | Looks up the raw CSV row, ordered field list, large-number formatting (commas + K/M/B for Market Cap, Enterprise Value, Volume, Avg Volume, Income, Sales, etc.), quote fallback. |
+| `app.py` (inline script + CSS) | Opens modal, fetches `/api/ticker-metrics/...`, renders six columns of label/value rows; **News URL** shows as **Article** (hyperlink); labels split sensibly (e.g. parentheses, `Perf …`, `Inst …`, `Insider …`). Metrics area scrolls **vertically** only; no horizontal scroll. |
+
+**Formatting:** Selected numeric fields (market cap, volume, enterprise value, average volume, and similar) are normalized for display with commas and **K / M / B** suffixes. **Duplicate CSV headers** (e.g. FinViz `Dividend` twice) may still collapse to one value in the parsed row—same limitation as the bulk CSV import.
 
 ---
 
@@ -271,7 +284,7 @@ JSON cache under `.cache/`; TTLs vary (e.g. fast for live snapshot, longer for s
 
 ```
 Market Metrics Dashboard/
-├── app.py
+├── app.py                  # Dash app + `/api/ticker-metrics/<symbol>` route
 ├── .env                    # FINVIZ_API_KEY, FRED_API_KEY, …
 ├── watchlist.csv
 ├── config/macro_cbo.yaml   # Optional Macro Monitor labels
@@ -279,6 +292,7 @@ Market Metrics Dashboard/
 │   ├── layout.py           # Tabs + widget registry
 │   ├── callbacks.py
 │   ├── data_fetcher.py     # FinViz + helpers
+│   ├── ticker_metrics.py   # USA v152 row lookup + modal metrics payload
 │   ├── finviz_elite.py
 │   ├── calculations.py     # Key metrics, RRG, stage, thematics
 │   ├── macro_fred_client.py

--- a/app.py
+++ b/app.py
@@ -172,6 +172,136 @@ app.index_string = f"""<!DOCTYPE html>
             background: rgba(6, 182, 212, 0.2) !important;
             color: {COLORS['text_muted']} !important;
         }}
+
+        /* TradingView modal — metrics panel (Finviz-style grid) */
+        .tv-modal-body {{
+            align-items: stretch;
+        }}
+        @media (max-width: 900px) {{
+            .tv-modal-body {{
+                flex-direction: column !important;
+            }}
+            .tv-metrics-panel {{
+                flex: 1 1 auto !important;
+                max-width: none !important;
+                min-width: 0 !important;
+                border-left: none !important;
+                border-top: 1px solid {COLORS['border']} !important;
+                max-height: 42vh;
+            }}
+            .tv-modal-chart-wrap {{
+                flex: 1 1 50% !important;
+                min-height: 200px;
+            }}
+        }}
+        .tv-metrics-body-inner {{
+            font-size: 11px;
+            line-height: 1.4;
+            padding: 8px 8px 6px;
+            color: {COLORS['text']};
+            box-sizing: border-box;
+        }}
+        .tv-metrics-loading, .tv-metrics-err, .tv-metrics-empty {{
+            padding: 12px;
+            font-size: 11px;
+            color: {COLORS['text_muted']};
+        }}
+        .tv-metrics-err {{ color: {COLORS['red_light']}; }}
+        .tv-metrics-source {{
+            flex-shrink: 0;
+            font-size: 9px;
+            color: {COLORS['accent']};
+            margin-bottom: 6px;
+            padding-bottom: 6px;
+            border-bottom: 1px solid {COLORS['border']};
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }}
+        .tv-metrics-fit-wrap {{
+            flex: 1 1 0;
+            min-height: 0;
+            overflow-x: hidden;
+            overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
+            padding-right: 10px;
+            box-sizing: border-box;
+        }}
+        .tv-metrics-fit-wrap::-webkit-scrollbar {{ width: 10px; }}
+        .tv-metrics-fit-wrap::-webkit-scrollbar-track {{ background: {COLORS['surface']}; border-radius: 4px; }}
+        .tv-metrics-fit-wrap::-webkit-scrollbar-thumb {{ background: {COLORS['border_light']}; border-radius: 4px; }}
+        .tv-metrics-scale-inner {{
+            box-sizing: border-box;
+            width: 100%;
+            max-width: 100%;
+            overflow-x: hidden;
+        }}
+        .tv-metrics-grid {{
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            align-items: flex-start;
+            gap: 0;
+            width: 100%;
+            max-width: 100%;
+            box-sizing: border-box;
+        }}
+        .tv-metrics-col {{
+            flex: 1 1 0;
+            min-width: 0;
+            box-sizing: border-box;
+            border-right: 1px solid {COLORS['border']};
+            padding: 0 4px 0 0;
+        }}
+        .tv-metrics-col:last-child {{ border-right: none; padding-right: 0; }}
+        .tv-metrics-row {{
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+            column-gap: 4px;
+            align-items: start;
+            padding: 2px 0;
+            border-bottom: 1px solid rgba(255,255,255,0.05);
+        }}
+        .tv-metrics-lbl {{
+            color: {COLORS['text_muted']};
+            font-size: 10.5px;
+            line-height: 1.3;
+            min-width: 0;
+            word-break: normal;
+            overflow-wrap: break-word;
+            hyphens: none;
+        }}
+        .tv-metrics-lbl-line {{
+            display: inline;
+            white-space: normal;
+            word-break: normal;
+        }}
+        .tv-metrics-lbl-sub {{
+            color: {COLORS['text_faint']};
+            font-size: 9.5px;
+            font-weight: 500;
+        }}
+        .tv-metrics-val {{
+            color: {COLORS['text']};
+            font-size: 10.5px;
+            line-height: 1.3;
+            text-align: right;
+            font-variant-numeric: tabular-nums lining-nums;
+            min-width: 0;
+            overflow-wrap: break-word;
+            word-break: normal;
+            hyphens: none;
+        }}
+        .tv-metrics-val.tv-pos {{ color: {COLORS['green_light']}; }}
+        .tv-metrics-val.tv-neg {{ color: {COLORS['red_light']}; }}
+        a.tv-metrics-val.tv-metrics-link {{
+            color: {COLORS['accent']};
+            text-decoration: underline;
+            text-underline-offset: 2px;
+            white-space: nowrap;
+        }}
+        a.tv-metrics-val.tv-metrics-link:hover {{
+            color: {COLORS['text']};
+        }}
     </style>
 </head>
 <body>
@@ -182,6 +312,128 @@ app.index_string = f"""<!DOCTYPE html>
         {{%renderer%}}
     </footer>
     <script>
+        var tvMetricsAbort = null;
+
+        function tvMetricsEscapeHtml(s) {{
+            return String(s)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;');
+        }}
+
+        function tvMetricsEscapeAttr(s) {{
+            return String(s)
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }}
+
+        function tvMetricsToneValue(label, value) {{
+            if (!value || value === '\\u2014' || value === '-') return 'neu';
+            var m = String(value).replace(/,/g, '').trim().match(/^([+-]?\\d+\\.?\\d*)\\s*%?$/);
+            if (m) {{
+                var n = parseFloat(m[1]);
+                if (n > 0) return 'pos';
+                if (n < 0) return 'neg';
+            }}
+            return 'neu';
+        }}
+
+        function tvMetricsSafeHref(val) {{
+            var s = String(val).trim();
+            if (/^https?:\\/\\//i.test(s)) return s;
+            return null;
+        }}
+
+        function tvMetricsIsNewsUrlLabel(label) {{
+            return String(label).trim().toLowerCase() === 'news url';
+        }}
+
+        /** Split labels at parentheses or Perf … so words are not broken mid-word by CSS. */
+        function tvMetricsFormatLabelHtml(label) {{
+            var s = String(label).trim();
+            var mParen = s.match(/^(.+?)\\s*(\\([^)]+\\))\\s*$/);
+            if (mParen && mParen[1].length >= 1) {{
+                var head = mParen[1].trim();
+                var tail = mParen[2].trim();
+                return '<span class="tv-metrics-lbl-line">' + tvMetricsEscapeHtml(head) + '</span><br>'
+                    + '<span class="tv-metrics-lbl-line tv-metrics-lbl-sub">' + tvMetricsEscapeHtml(tail) + '</span>';
+            }}
+            var mPerf = s.match(/^Perf\\s+(.+)$/i);
+            if (mPerf) {{
+                var rest = mPerf[1].trim();
+                return '<span class="tv-metrics-lbl-line">Performance</span><br>'
+                    + '<span class="tv-metrics-lbl-line tv-metrics-lbl-sub">(' + tvMetricsEscapeHtml(rest) + ')</span>';
+            }}
+            var mInsider = s.match(/^Insider\\s+(.+)$/i);
+            if (mInsider) {{
+                var ir = mInsider[1].trim();
+                return '<span class="tv-metrics-lbl-line">Insider</span><br>'
+                    + '<span class="tv-metrics-lbl-line tv-metrics-lbl-sub">(' + tvMetricsEscapeHtml(ir) + ')</span>';
+            }}
+            var mInst = s.match(/^Inst\\s+(.+)$/i);
+            if (mInst) {{
+                var it = mInst[1].trim();
+                return '<span class="tv-metrics-lbl-line">Institutional</span><br>'
+                    + '<span class="tv-metrics-lbl-line tv-metrics-lbl-sub">(' + tvMetricsEscapeHtml(it) + ')</span>';
+            }}
+            return '<span class="tv-metrics-lbl-line">' + tvMetricsEscapeHtml(s) + '</span>';
+        }}
+
+        function tvMetricsRenderValueCell(label, value, tone) {{
+            var cls = 'tv-metrics-val';
+            if (tone === 'pos') cls += ' tv-pos';
+            else if (tone === 'neg') cls += ' tv-neg';
+            var href = tvMetricsIsNewsUrlLabel(label) ? tvMetricsSafeHref(value) : null;
+            if (href) {{
+                return '<a class="' + cls + ' tv-metrics-link" href="' + tvMetricsEscapeAttr(href)
+                    + '" target="_blank" rel="noopener noreferrer" title="' + tvMetricsEscapeAttr(value)
+                    + '" onclick="event.stopPropagation()">Article</a>';
+            }}
+            return '<span class="' + cls + '" title="' + tvMetricsEscapeAttr(value) + '">'
+                + tvMetricsEscapeHtml(value) + '</span>';
+        }}
+
+        function tvMetricsRenderPairs(pairs) {{
+            if (!pairs || !pairs.length)
+                return '<div class="tv-metrics-empty">No metrics.</div>';
+            var cols = 6;
+            var n = pairs.length;
+            var perCol = Math.ceil(n / cols);
+            var html = '<div class="tv-metrics-grid">';
+            for (var c = 0; c < cols; c++) {{
+                html += '<div class="tv-metrics-col">';
+                for (var i = c * perCol; i < Math.min((c + 1) * perCol, n); i++) {{
+                    var p = pairs[i];
+                    var tone = tvMetricsToneValue(p.label, p.value);
+                    html += '<div class="tv-metrics-row"><span class="tv-metrics-lbl" title="'
+                        + tvMetricsEscapeAttr(p.label)
+                        + '">'
+                        + tvMetricsFormatLabelHtml(p.label)
+                        + '</span>'
+                        + tvMetricsRenderValueCell(p.label, p.value, tone)
+                        + '</div>';
+                }}
+                html += '</div>';
+            }}
+            html += '</div>';
+            return html;
+        }}
+
+        function tvModalClose() {{
+            if (tvMetricsAbort) {{
+                try {{ tvMetricsAbort.abort(); }} catch (e) {{}}
+                tvMetricsAbort = null;
+            }}
+            var modal = document.getElementById('tv-modal');
+            var iframe = document.getElementById('tv-iframe');
+            var panel = document.getElementById('tv-metrics-body');
+            if (modal) modal.style.display = 'none';
+            if (iframe) iframe.src = '';
+            if (panel) panel.innerHTML = '';
+        }}
+
         document.addEventListener('click', function(e) {{
             var el = e.target.closest('.tv-ticker');
             if (!el) return;
@@ -192,18 +444,61 @@ app.index_string = f"""<!DOCTYPE html>
             var modal = document.getElementById('tv-modal');
             var iframe = document.getElementById('tv-iframe');
             var title = document.getElementById('tv-modal-title');
+            var panel = document.getElementById('tv-metrics-body');
             if (!modal || !iframe) return;
 
             e.preventDefault();
             e.stopPropagation();
 
-            title.textContent = symbol + ' \u2014 TradingView';
+            if (tvMetricsAbort) {{
+                try {{ tvMetricsAbort.abort(); }} catch (err) {{}}
+            }}
+            tvMetricsAbort = new AbortController();
+
+            title.textContent = symbol + ' \\u2014 TradingView';
             iframe.src = 'https://s.tradingview.com/widgetembed/?frameElementId=tv-widget'
                 + '&symbol=' + encodeURIComponent(symbol)
                 + '&interval=D&hidesidetoolbar=0&symboledit=1&saveimage=1'
                 + '&toolbarbg=f1f3f6&studies=MASimple%409%2CRSI%40RSI'
                 + '&theme=dark&style=1&timezone=America%2FNew_York'
                 + '&withdateranges=1&showpopupbutton=1&locale=en';
+
+            if (panel)
+                panel.innerHTML = '<div class="tv-metrics-loading">Loading\\u2026</div>';
+
+            fetch('/api/ticker-metrics/' + encodeURIComponent(symbol), {{
+                signal: tvMetricsAbort.signal,
+            }})
+                .then(function (resp) {{
+                    return resp.json().then(function (data) {{
+                        return {{ okHttp: resp.ok, status: resp.status, data: data }};
+                    }});
+                }})
+                .then(function (result) {{
+                    var p = document.getElementById('tv-metrics-body');
+                    if (!p) return;
+                    if (tvMetricsAbort && tvMetricsAbort.signal.aborted) return;
+                    var d = result.data;
+                    if (!d || !d.ok) {{
+                        var msg = (d && d.message) ? d.message : 'No data for this symbol.';
+                        p.innerHTML = '<div class="tv-metrics-err">' + tvMetricsEscapeHtml(msg) + '</div>';
+                        return;
+                    }}
+                    var src = d.source || '';
+                    var meta = src === 'quote'
+                        ? '<div class="tv-metrics-source">Quote snapshot (not in USA export)</div>'
+                        : '';
+                    p.innerHTML = meta
+                        + '<div class="tv-metrics-fit-wrap"><div class="tv-metrics-scale-inner">'
+                        + tvMetricsRenderPairs(d.pairs || [])
+                        + '</div></div>';
+                }})
+                .catch(function (err) {{
+                    if (err.name === 'AbortError') return;
+                    var p = document.getElementById('tv-metrics-body');
+                    if (p)
+                        p.innerHTML = '<div class="tv-metrics-err">Failed to load metrics.</div>';
+                }});
 
             modal.style.display = 'flex';
             modal.style.position = 'fixed';
@@ -219,21 +514,12 @@ app.index_string = f"""<!DOCTYPE html>
         document.addEventListener('click', function(e) {{
             var modal = document.getElementById('tv-modal');
             if (!modal) return;
-            if (e.target === modal) {{
-                modal.style.display = 'none';
-                var iframe = document.getElementById('tv-iframe');
-                if (iframe) iframe.src = '';
-            }}
+            if (e.target === modal) tvModalClose();
         }});
 
         document.addEventListener('click', function(e) {{
             var btn = e.target.closest('#btn-tv-close');
-            if (btn) {{
-                var modal = document.getElementById('tv-modal');
-                if (modal) modal.style.display = 'none';
-                var iframe = document.getElementById('tv-iframe');
-                if (iframe) iframe.src = '';
-            }}
+            if (btn) tvModalClose();
         }});
 
         /* Inject dropdown dark theme after Dash components load (overrides async-loaded CSS) */
@@ -282,6 +568,25 @@ app.index_string = f"""<!DOCTYPE html>
 
 app.layout = build_layout()
 register_callbacks(app)
+
+
+@app.server.route("/api/ticker-metrics/<symbol>")
+def _api_ticker_metrics(symbol: str):
+    from flask import jsonify
+
+    from src.ticker_metrics import get_ticker_metrics_payload, is_valid_symbol_param
+
+    if not is_valid_symbol_param(symbol):
+        return jsonify({"ok": False, "message": "Invalid symbol.", "pairs": []}), 400
+
+    payload = get_ticker_metrics_payload(symbol)
+    if payload.get("ok"):
+        return jsonify(payload)
+
+    msg = (payload.get("message") or "").lower()
+    if "not configured" in msg or "finviz elite" in msg:
+        return jsonify(payload), 503
+    return jsonify(payload), 404
 
 
 @app.server.after_request

--- a/src/layout.py
+++ b/src/layout.py
@@ -2572,24 +2572,69 @@ def build_tv_modal() -> html.Div:
                 "display": "flex", "justifyContent": "space-between",
                 "alignItems": "center", "padding": "6px 10px",
                 "borderBottom": f"1px solid {COLORS['border']}",
+                "flexShrink": 0,
             }),
-            html.Iframe(
-                id="tv-iframe",
-                style={
-                    "width": "100%",
-                    "height": "calc(100% - 32px)",
-                    "border": "none",
-                },
-            ),
-        ], style={
-            "width": "80vw",
-            "height": "75vh",
-            "maxWidth": "1200px",
+            html.Div([
+                html.Div([
+                    html.Iframe(
+                        id="tv-iframe",
+                        className="tv-modal-iframe",
+                        style={
+                            "width": "100%",
+                            "flex": "1",
+                            "minHeight": "0",
+                            "border": "none",
+                        },
+                    ),
+                ], className="tv-modal-chart-wrap", style={
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "flex": "1 1 55%",
+                    "minWidth": "0",
+                    "minHeight": "0",
+                }),
+                html.Div([
+                    html.Div(
+                        "Loading…",
+                        id="tv-metrics-body",
+                        className="tv-metrics-body-inner",
+                        style={
+                            "flex": "1",
+                            "minHeight": "0",
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "overflow": "hidden",
+                        },
+                    ),
+                ], id="tv-metrics-panel", className="tv-metrics-panel", style={
+                    "flex": "1 1 44%",
+                    "maxWidth": "min(580px, 48vw)",
+                    "minWidth": "min(340px, 92vw)",
+                    "minHeight": "0",
+                    "overflow": "hidden",
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "borderLeft": f"1px solid {COLORS['border']}",
+                    "backgroundColor": COLORS["surface2"],
+                }),
+            ], className="tv-modal-body", style={
+                "display": "flex",
+                "flexDirection": "row",
+                "flex": "1",
+                "minHeight": "0",
+                "overflow": "hidden",
+            }),
+        ], className="tv-modal-card", style={
+            "width": "min(95vw, 1400px)",
+            "height": "min(85vh, 900px)",
+            "maxWidth": "1400px",
             "backgroundColor": COLORS["surface"],
             "borderRadius": "6px",
             "border": f"1px solid {COLORS['border']}",
             "overflow": "hidden",
             "boxShadow": "0 8px 32px rgba(0,0,0,0.6)",
+            "display": "flex",
+            "flexDirection": "column",
         }),
     ], id="tv-modal", style={
         "display": "none",

--- a/src/ticker_metrics.py
+++ b/src/ticker_metrics.py
@@ -1,0 +1,339 @@
+"""Ticker metrics for TradingView modal: raw USA v=152 row + quote fallback."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from src.data_fetcher import _parse_num
+from src.usa_v152_columns import USA_V152
+
+U = USA_V152
+
+# Large numeric fields: show with commas and K/M/B (same idea as Market Cap, Volume, etc.)
+_FORMAT_VALUE_LABELS: frozenset[str] = frozenset({
+    U.MARKET_CAP,
+    U.ENTERPRISE_VALUE,
+    U.VOLUME,
+    U.AVG_VOLUME,
+    U.INCOME,
+    U.SALES,
+    U.OUTSTANDING,
+    U.FLOAT,
+    U.SHORT_INTEREST,
+    U.TRADES,
+    U.AH_VOLUME,
+    U.AUM,
+    U.HOLDINGS,
+    "Average Volume",  # quote.ashx / alternate header
+})
+
+# Finviz-like flow: identity → valuation → income/dividends → balance/liquidity →
+# ownership/short → margins → intraday perf → longer perf → technicals → price/flow → ETF extras → tags.
+V152_DISPLAY_ORDER: tuple[str, ...] = (
+    U.NO,
+    U.TICKER,
+    U.COMPANY,
+    U.INDEX,
+    U.SECTOR,
+    U.INDUSTRY,
+    U.COUNTRY,
+    U.EXCHANGE,
+    U.MARKET_CAP,
+    U.ENTERPRISE_VALUE,
+    U.INCOME,
+    U.SALES,
+    U.BOOK_SH,
+    U.CASH_SH,
+    U.DIVIDEND,
+    U.DIVIDEND_TTM,
+    U.DIVIDEND_EX_DATE,
+    U.DIVIDEND_GR_1Y,
+    U.DIVIDEND_GR_3Y,
+    U.DIVIDEND_GR_5Y,
+    U.PAYOUT_RATIO,
+    U.EMPLOYEES,
+    U.IPO_DATE,
+    U.PE,
+    U.FWD_PE,
+    U.PEG,
+    U.PS,
+    U.PB,
+    U.PC,
+    U.P_FCF,
+    U.EV_EBITDA,
+    U.EV_SALES,
+    U.QUICK_R,
+    U.CURR_R,
+    U.DEBT_EQ,
+    U.LTDEBT_EQ,
+    U.EPS,
+    U.EPS_NEXT_Q,
+    U.EPS_NEXT_Y,
+    U.EPS_THIS_Y,
+    U.EPS_NEXT_5Y,
+    U.EPS_PAST_5Y,
+    U.EPS_PAST_3Y,
+    U.SALES_PAST_5Y,
+    U.SALES_PAST_3Y,
+    U.SALES_YOY_TTM,
+    U.SALES_Q_Q,
+    U.EPS_YOY_TTM,
+    U.EPS_Q_Q,
+    U.EPS_SURPRISE,
+    U.REVENUE_SURPRISE,
+    U.EARNINGS,
+    U.INSIDER_OWN,
+    U.INSIDER_TRANS,
+    U.INST_OWN,
+    U.INST_TRANS,
+    U.ROA,
+    U.ROE,
+    U.ROIC,
+    U.GROSS_M,
+    U.OPER_M,
+    U.PROFIT_M,
+    U.SMA20,
+    U.SMA50,
+    U.SMA200,
+    U.OUTSTANDING,
+    U.FLOAT,
+    U.FLOAT_PCT,
+    U.SHORT_FLOAT,
+    U.SHORT_RATIO,
+    U.SHORT_INTEREST,
+    U.HIGH_52W,
+    U.LOW_52W,
+    U.RANGE_52W,
+    U.HIGH_50D,
+    U.LOW_50D,
+    U.ALL_TIME_HIGH,
+    U.ALL_TIME_LOW,
+    U.VOLATILITY_W,
+    U.VOLATILITY_M,
+    U.ATR,
+    U.RSI,
+    U.BETA,
+    U.REL_VOLUME,
+    U.AVG_VOLUME,
+    U.VOLUME,
+    U.TRADES,
+    U.PERF_WEEK,
+    U.PERF_MONTH,
+    U.PERF_QUART,
+    U.PERF_HALF,
+    U.PERF_YTD,
+    U.PERF_YEAR,
+    U.PERF_3Y,
+    U.PERF_5Y,
+    U.PERF_10Y,
+    U.PERF_1_MIN,
+    U.PERF_2_MIN,
+    U.PERF_3_MIN,
+    U.PERF_5_MIN,
+    U.PERF_10_MIN,
+    U.PERF_15_MIN,
+    U.PERF_30_MIN,
+    U.PERF_1_HR,
+    U.PERF_2_HR,
+    U.PERF_4_HR,
+    U.RECOM,
+    U.TARGET_PRICE,
+    U.PREV_CLOSE,
+    U.PRICE,
+    U.CHANGE,
+    U.OPEN,
+    U.HIGH,
+    U.LOW,
+    U.CHANGE_FROM_OPEN,
+    U.GAP,
+    U.AH_CLOSE,
+    U.AH_CHANGE,
+    U.AH_VOLUME,
+    U.NEWS_TIME,
+    U.NEWS_TITLE,
+    U.NEWS_URL,
+    U.DAILY_DIGEST,
+    U.SINGLE_CATEGORY,
+    U.ASSET_TYPE,
+    U.ETF_TYPE,
+    U.SECTOR_THEME,
+    U.REGION,
+    U.ACTIVE,
+    U.EXPENSE,
+    U.HOLDINGS,
+    U.AUM,
+    U.NAV,
+    U.NAV_PCT,
+    U.FLOWS_1M,
+    U.FLOWS_PCT_1M,
+    U.FLOWS_3M,
+    U.FLOWS_PCT_3M,
+    U.FLOWS_YTD,
+    U.FLOWS_PCT_YTD,
+    U.FLOWS_1Y,
+    U.FLOWS_PCT_1Y,
+    U.RETURN_PCT_1Y,
+    U.RETURN_PCT_3Y,
+    U.RETURN_PCT_5Y,
+    U.RETURN_PCT_10Y,
+    U.RETURN_PCT_SI,
+    U.OPTIONABLE,
+    U.SHORTABLE,
+    U.TAG,
+    U.TAGS,
+)
+
+
+def _fmt_val(v: Any) -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        if v != v:  # NaN
+            return "—"
+    s = str(v).strip()
+    if not s or s in ("-", "—"):
+        return "—"
+    return s
+
+
+def _label_formats_large_numbers(label: str) -> bool:
+    key = str(label).strip().lower()
+    return key in {x.lower() for x in _FORMAT_VALUE_LABELS}
+
+
+def _format_finance_number(n: float) -> str:
+    """Format a scalar with comma separators and K / M / B suffix when appropriate."""
+    if n != n:  # NaN
+        return "—"
+    sign = "-" if n < 0 else ""
+    x = abs(n)
+    if x >= 1e9:
+        t = f"{x / 1e9:,.2f}".rstrip("0").rstrip(".")
+        return f"{sign}{t}B"
+    if x >= 1e6:
+        t = f"{x / 1e6:,.2f}".rstrip("0").rstrip(".")
+        return f"{sign}{t}M"
+    if x >= 1e3:
+        t = f"{x / 1e3:,.2f}".rstrip("0").rstrip(".")
+        return f"{sign}{t}K"
+    if x >= 1 and abs(x - round(x)) < 1e-9:
+        return f"{sign}{int(round(x)):,}"
+    return f"{sign}{x:,.2f}"
+
+
+def _fmt_metric_value(label: str, raw: Any) -> str:
+    """Display string; large-number columns get commas + K/M/B."""
+    base = _fmt_val(raw)
+    if base == "—":
+        return base
+    if not _label_formats_large_numbers(label):
+        return base
+    n = _parse_num(str(raw).strip()) if raw is not None else None
+    if n is None:
+        return base
+    return _format_finance_number(n)
+
+
+def get_raw_v152_row_for_ticker(symbol: str) -> dict | None:
+    """Return the raw CSV row dict for ``symbol`` from cached USA v=152 export, or None."""
+    from src.data_fetcher import fetch_usa_full_v152_raw
+
+    sym = (symbol or "").strip().upper()
+    if not sym:
+        return None
+    raw = fetch_usa_full_v152_raw()
+    if not raw:
+        return None
+    keys = list(raw[0].keys())
+    ticker_col = None
+    for k in keys:
+        if str(k).strip().lower() in ("ticker",):
+            ticker_col = k
+            break
+    if ticker_col is None:
+        ticker_col = U.TICKER
+    for row in raw:
+        t = str(row.get(ticker_col, "") or "").strip().upper()
+        if t == sym:
+            return row
+    return None
+
+
+def _pairs_from_raw_row(row: dict) -> list[dict[str, str]]:
+    """Ordered label/value pairs; known order first, then extras sorted alphabetically."""
+    seen: set[str] = set()
+    pairs: list[dict[str, str]] = []
+    for col in V152_DISPLAY_ORDER:
+        if col not in row:
+            continue
+        seen.add(col)
+        pairs.append({"label": col, "value": _fmt_metric_value(col, row.get(col))})
+    extras = [k for k in row.keys() if k not in seen and str(k).strip()]
+    extras.sort(key=lambda x: str(x).lower())
+    for k in extras:
+        pairs.append({"label": str(k), "value": _fmt_metric_value(str(k), row.get(k))})
+    return pairs
+
+
+def get_ticker_metrics_payload(symbol: str) -> dict:
+    """
+    Return JSON-serializable payload for the modal metrics panel.
+
+    Keys: ok (bool), symbol (str), source (str), pairs (list), message (optional).
+    """
+    sym = (symbol or "").strip().upper()
+    if not sym:
+        return {
+            "ok": False,
+            "symbol": "",
+            "source": "unavailable",
+            "pairs": [],
+            "message": "Missing symbol.",
+        }
+
+    row = get_raw_v152_row_for_ticker(sym)
+    if row:
+        return {
+            "ok": True,
+            "symbol": sym,
+            "source": "usa_v152",
+            "pairs": _pairs_from_raw_row(row),
+        }
+
+    from src.finviz_elite import fetch_elite_stock, is_elite_configured
+
+    if not is_elite_configured():
+        return {
+            "ok": False,
+            "symbol": sym,
+            "source": "unavailable",
+            "pairs": [],
+            "message": "FinViz Elite not configured and symbol not in cached USA export.",
+        }
+
+    q = fetch_elite_stock(sym)
+    if not q:
+        return {
+            "ok": False,
+            "symbol": sym,
+            "source": "unavailable",
+            "pairs": [],
+            "message": "No data for this symbol (try refreshing the dashboard to load the USA export).",
+        }
+
+    pairs = [{"label": k, "value": _fmt_metric_value(str(k), v)} for k, v in q.items()]
+    return {
+        "ok": True,
+        "symbol": sym,
+        "source": "quote",
+        "pairs": pairs,
+    }
+
+
+SYMBOL_PATTERN = re.compile(r"^[A-Za-z0-9.\-^]+$")
+
+
+def is_valid_symbol_param(symbol: str) -> bool:
+    s = (symbol or "").strip()
+    return bool(s) and bool(SYMBOL_PATTERN.fullmatch(s))


### PR DESCRIPTION
- Add GET /api/ticker-metrics/<symbol> on Flask; JSON from USA v=152 row or Elite quote.ashx fallback (src/ticker_metrics.py)
- Modal: chart + six-column metrics grid; vertical scroll only; right padding beside scrollbar; larger type
- Label rendering: split on parentheses, Perf/Inst/Insider patterns; News URL as 'Article' link
- Format large fields (market cap, EV, volume, avg volume, etc.) with commas and K/M/B
- README: document ticker click behavior, API, and ticker_metrics.py